### PR TITLE
Refactor: AutoCompleteInput에서 type에러 발생한 부분 해결

### DIFF
--- a/okivery/src/components/address/AutoCompleteInput.tsx
+++ b/okivery/src/components/address/AutoCompleteInput.tsx
@@ -2,24 +2,27 @@ import { Loader } from "@googlemaps/js-api-loader";
 import { useEffect, useRef } from "react";
 import isWithinOneKm from "./CalculateDistance";
 import centerLocation from "../../constants/location";
+import { AddressType } from "../../pages/AddressPage";
 
 interface AutoCompleteInputProps {
   // 옵션은 props로 관리 필요하면 더 추가하기.
+  addressData: AddressType;
+  setAddressData: React.Dispatch<React.SetStateAction<AddressType>>;
   options: google.maps.places.AutocompleteOptions;
-  handleInputChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  mainAddressData: string | undefined;
   setIsAvailableService: React.Dispatch<React.SetStateAction<boolean>>;
+  handleInputChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 // 자동 검색 인풋을 컴포넌트로 추상화
 const AutoCompleteInput = ({
+  setAddressData,
+  addressData,
   options = {
     types: ["establishment"],
     fields: ["place_id", "geometry", "name"],
   },
   setIsAvailableService,
   handleInputChange,
-  mainAddressData,
 }: AutoCompleteInputProps) => {
   // 구글에서 제공해주는 기능들을 input과 연결하기위해 ref사용
   const inputRef = useRef<HTMLInputElement>(null);
@@ -47,17 +50,16 @@ const AutoCompleteInput = ({
         options
       );
 
-      // 클릭했을때 그 주소를 AddressData.mainAddress에 값 저장
+      // 자동완성된 주소를 AddressData.mainAddress에 값 저장
       autocomplete.addListener("place_changed", () => {
         const place = autocomplete.getPlace();
         const address = place.formatted_address || "";
-        handleInputChange({
-          // 타입 에러
-          target: {
-            name: "mainAddress",
-            value: address,
-          },
+
+        setAddressData({
+          ...addressData,
+          mainAddress: address,
         });
+
         // 선택한 주소 위도 경도로 변환
         const geocoder = new google.maps.Geocoder();
         geocoder.geocode(
@@ -88,7 +90,7 @@ const AutoCompleteInput = ({
       id="mainAddress"
       name="mainAddress"
       type="text"
-      value={mainAddressData}
+      value={addressData.mainAddress}
       onChange={handleInputChange}
       placeholder="Type in your address or Press the button above"
     />

--- a/okivery/src/pages/AddressPage/index.tsx
+++ b/okivery/src/pages/AddressPage/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { ChangeEventHandler, useEffect, useState } from "react";
 import "./AddressPage.css";
 import Header from "@components/common/header/Header";
 import selectMapIcon from "../../assets/icons/selectMapIcon.png";
@@ -9,7 +9,7 @@ import Button from "@components/common/button/Button";
 import GoogleMapModal from "@components/address/GoogleMapModal";
 import AutoCompleteInput from "@components/address/AutoCompleteInput";
 
-type AddressType = {
+export type AddressType = {
   mainAddress: string;
   subAddress: string;
 };
@@ -27,7 +27,7 @@ const AddressPage: React.FC = () => {
   });
   const [isMapModalOpen, setIsMapModalOpen] = useState<boolean>(false);
 
-  const handleInputChange = (
+  const handleInputChange: ChangeEventHandler<HTMLInputElement> = (
     event: React.ChangeEvent<HTMLInputElement>
   ): void => {
     const { name, value } = event.target;
@@ -35,7 +35,6 @@ const AddressPage: React.FC = () => {
       ...addressData,
       [name]: value,
     });
-    console.log(addressData);
   };
 
   useEffect(() => {
@@ -48,6 +47,8 @@ const AddressPage: React.FC = () => {
 
   const handleSave = (): void => {
     // db로 post
+    alert(`mainAddress: ${addressData.mainAddress},
+    subAddress: ${addressData.subAddress}`);
     isAvailableService && isAllFilled && navigate(-1);
   };
 
@@ -91,13 +92,14 @@ const AddressPage: React.FC = () => {
             <div className="selectAddressTextInput">
               <div className="mainAddressInput">
                 <AutoCompleteInput
+                  addressData={addressData}
+                  setAddressData={setAddressData}
                   setIsAvailableService={setIsAvailableService}
-                  mainAddressData={addressData.mainAddress}
-                  handleInputChange={handleInputChange}
                   options={{
                     strictBounds: true,
                     componentRestrictions: { country: "KR" },
                   }}
+                  handleInputChange={handleInputChange}
                 />
               </div>
             </div>


### PR DESCRIPTION
AutoCompleteInput의 autocomplete.addEventListener부분의 handleInputChange 함수내 코드에서 나던 target의 타입 에러를 해결
-> 그 부분의 handleInputChange 함수를 삭제 
-> AddressPage의 addressData와 setAddressData를 props로 받아와 그 안에 setAddressData로 자동완성된 주소를 저장